### PR TITLE
Adding more general way to to do revision detection

### DIFF
--- a/lib/capistrano/tasks/tar.rake
+++ b/lib/capistrano/tasks/tar.rake
@@ -8,7 +8,7 @@ namespace :tar do
 
     on release_roles :all do
       pkg = ENV['package']
-      rev = (File.basename(pkg).split('.')-['tar', 'gz', 'tgz']).join('.')
+      rev = (File.basename(pkg).split('.') - ['tar', 'gz', 'tgz']).join('.')
       tmp = capture 'mktemp'
 
       # upload tarball

--- a/lib/capistrano/tasks/tar.rake
+++ b/lib/capistrano/tasks/tar.rake
@@ -8,7 +8,7 @@ namespace :tar do
 
     on release_roles :all do
       pkg = ENV['package']
-      rev = ( File.basename(pkg).split('.') - [ 'tar', 'gz', 'tgz' ] ).join('.')
+      rev = (File.basename(pkg).split('.')-['tar', 'gz', 'tgz']).join('.')
       tmp = capture 'mktemp'
 
       # upload tarball
@@ -28,4 +28,3 @@ namespace :tar do
   task :set_current_revision
 
 end
-

--- a/lib/capistrano/tasks/tar.rake
+++ b/lib/capistrano/tasks/tar.rake
@@ -8,7 +8,7 @@ namespace :tar do
 
     on release_roles :all do
       pkg = ENV['package']
-      rev = File.basename(pkg).split('.')[0]
+      rev = ( File.basename(pkg).split('.') - [ 'tar', 'gz', 'tgz' ] ).join('.')
       tmp = capture 'mktemp'
 
       # upload tarball


### PR DESCRIPTION
We use tar -xz which specifies to unpack a gzip, so I think it's a fair assumption that if there's a file extension it will be either tar, gz, or tgz

The current implementation breaks with a version of "0.12.0" by setting rev to 0
```
irb(main):014:0> File.basename('/tmp/foo/0.12.0.tar.gz').split('.')[0]
=> "0"
```

Here is the new implementation
```
irb(main):015:0> (File.basename('/tmp/foo/0.12.0.tar.gz').split('.') - ['tar', 'gz', 'tgz']).join('.')
=> "0.12.0"
```